### PR TITLE
Build out single shopping list UI and single food item UI (mockup)

### DIFF
--- a/lib/screens/fridge.dart
+++ b/lib/screens/fridge.dart
@@ -24,14 +24,14 @@ class FridgeScreen extends StatelessWidget {
           backgroundColor: Colors.green,
           foregroundColor: Colors.white,
           onPressed: () {
-            _showOverlay(context);
+            _showCreateFoodItemOverlay(context);
           },
         ),
       ),
     );
   }
 
-  void _showOverlay(BuildContext context) {
+  void _showCreateFoodItemOverlay(BuildContext context) {
     Navigator.of(context).push(
       FullScreenOverlay(
         RouteSettings(

--- a/lib/screens/fridge.dart
+++ b/lib/screens/fridge.dart
@@ -48,10 +48,12 @@ class FridgeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Query(
         options: QueryOptions(
-          documentNode: gql(FoodItemsService.getFoodItemsByHouseholdIdQuery),
+          documentNode: gql(FoodItemsService.foodItemsQuery),
           variables: {
             // TODO: Get this from the user when auth stuff is sorted out and user is available here
-            'householdId': 1,
+            'foodItemsQueryInput': {
+              'householdId': 1,
+            }
           },
           pollInterval: 5,
         ),

--- a/lib/screens/fridge.dart
+++ b/lib/screens/fridge.dart
@@ -4,12 +4,11 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import '../services/foodItems.dart';
-import '../widgets/createFoodItemForm.dart';
-import '../widgets/fullscreenOverlay.dart';
 import '../widgets/loadingSpinner.dart';
 import '../widgets/pageTitle.dart';
 import '../widgets/pageSubtitle.dart';
 import '../widgets/tappableCard.dart';
+import '../utils/showOverlayUtils.dart';
 
 class FridgeScreen extends StatelessWidget {
   // Each screen that has a floating action button will have this method
@@ -24,22 +23,9 @@ class FridgeScreen extends StatelessWidget {
           backgroundColor: Colors.green,
           foregroundColor: Colors.white,
           onPressed: () {
-            _showCreateFoodItemOverlay(context);
+            ShowOverlay.showCreateFoodItemOverlay(context);
           },
         ),
-      ),
-    );
-  }
-
-  void _showCreateFoodItemOverlay(BuildContext context) {
-    Navigator.of(context).push(
-      FullScreenOverlay(
-        RouteSettings(
-          arguments: FullScreenOverlayRouteArguments(
-            CreateFoodItemForm(),
-          ),
-        ),
-        ImageFilter.blur(),
       ),
     );
   }

--- a/lib/screens/navContainer.dart
+++ b/lib/screens/navContainer.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import '../services/auth.dart';
 import '../widgets/bottomNavBar.dart';
-import './fridge.dart';
-import './home.dart';
-import './shoppingLists.dart';
+import 'fridge.dart';
+import 'home.dart';
+import 'shoppingLists.dart';
 
 class NavContainerScreen extends StatefulWidget {
   NavContainerScreen({Key key, @required this.authService}) : super(key: key);

--- a/lib/screens/shoppingLists.dart
+++ b/lib/screens/shoppingLists.dart
@@ -32,12 +32,15 @@ class ShoppingListsScreen extends StatelessWidget {
     );
   }
 
-  void _showViewSingleShoppingListOverlay(BuildContext context) {
+  void _showViewSingleShoppingListOverlay(
+      BuildContext context, Map shoppingListData) {
     Navigator.of(context).push(
       FullScreenOverlay(
         RouteSettings(
           arguments: FullScreenOverlayRouteArguments(
-            SingleShoppingList(),
+            SingleShoppingList(
+              shoppingListData: shoppingListData,
+            ),
           ),
         ),
         ImageFilter.blur(),
@@ -45,7 +48,9 @@ class ShoppingListsScreen extends StatelessWidget {
     );
   }
 
-  void _showCreateShoppingListOverlay(BuildContext context) {
+  void _showCreateShoppingListOverlay(
+    BuildContext context,
+  ) {
     Navigator.of(context).push(
       FullScreenOverlay(
         RouteSettings(
@@ -115,7 +120,11 @@ class ShoppingListsScreen extends StatelessWidget {
                             ),
                             child: Column(
                               children: result.data['shoppingLists']
-                                  .map<TappableCard>((shoppingList) {
+                                  .asMap()
+                                  .entries
+                                  .map<TappableCard>((entry) {
+                                final shoppingList = entry.value;
+                                final index = entry.key;
                                 return TappableCard(
                                   children: <Widget>[
                                     ListTile(
@@ -126,7 +135,8 @@ class ShoppingListsScreen extends StatelessWidget {
                                     ),
                                   ],
                                   onTap: () {
-                                    _showViewSingleShoppingListOverlay(context);
+                                    _showViewSingleShoppingListOverlay(context,
+                                        result.data['shoppingLists'][index]);
                                   },
                                 );
                               }).toList(),

--- a/lib/screens/shoppingLists.dart
+++ b/lib/screens/shoppingLists.dart
@@ -102,46 +102,52 @@ class ShoppingListsScreen extends StatelessWidget {
                     topPadding: 0.0,
                   ),
                 ),
-                result.hasException
-                    ? Center(
-                        child: Text(
-                          result.exception.toString(),
-                          style: TextStyle(
-                            color: Colors.red,
-                            fontSize: 20.0,
-                          ),
-                        ),
-                      )
-                    : result.loading
-                        ? LoadingSpinner()
-                        : Padding(
-                            padding: EdgeInsets.symmetric(
-                              horizontal: 30.0,
+                Column(
+                  children: <Widget>[
+                    result.hasException
+                        ? Center(
+                            child: Text(
+                              result.exception.toString(),
+                              style: TextStyle(
+                                color: Colors.red,
+                                fontSize: 20.0,
+                              ),
                             ),
-                            child: Column(
-                              children: result.data['shoppingLists']
-                                  .asMap()
-                                  .entries
-                                  .map<TappableCard>((entry) {
-                                final shoppingList = entry.value;
-                                final index = entry.key;
-                                return TappableCard(
-                                  children: <Widget>[
-                                    ListTile(
-                                      leading: Icon(Icons.list),
-                                      title: Text(shoppingList['name']),
-                                      subtitle:
-                                          Text(shoppingList['description']),
-                                    ),
-                                  ],
-                                  onTap: () {
-                                    _showViewSingleShoppingListOverlay(context,
-                                        result.data['shoppingLists'][index]);
-                                  },
-                                );
-                              }).toList(),
-                            ),
-                          ),
+                          )
+                        : result.loading
+                            ? LoadingSpinner()
+                            : Padding(
+                                padding: EdgeInsets.symmetric(
+                                  horizontal: 30.0,
+                                ),
+                                child: Column(
+                                  children: result.data['shoppingLists']
+                                      .asMap()
+                                      .entries
+                                      .map<TappableCard>((entry) {
+                                    final shoppingList = entry.value;
+                                    final index = entry.key;
+                                    return TappableCard(
+                                      children: <Widget>[
+                                        ListTile(
+                                          leading: Icon(Icons.list),
+                                          title: Text(shoppingList['name']),
+                                          subtitle:
+                                              Text(shoppingList['description']),
+                                        ),
+                                      ],
+                                      onTap: () {
+                                        _showViewSingleShoppingListOverlay(
+                                            context,
+                                            result.data['shoppingLists']
+                                                [index]);
+                                      },
+                                    );
+                                  }).toList(),
+                                ),
+                              ),
+                  ],
+                ),
               ],
             ),
           );

--- a/lib/screens/shoppingLists.dart
+++ b/lib/screens/shoppingLists.dart
@@ -10,6 +10,7 @@ import '../widgets/pageSubtitle.dart';
 import '../widgets/tappableCard.dart';
 import '../widgets/fullscreenOverlay.dart';
 import '../widgets/createShoppingListForm.dart';
+import '../widgets/singleShoppingList.dart';
 
 class ShoppingListsScreen extends StatelessWidget {
   // Each screen that has a floating action button will have this method
@@ -24,14 +25,27 @@ class ShoppingListsScreen extends StatelessWidget {
           backgroundColor: Colors.green,
           foregroundColor: Colors.white,
           onPressed: () {
-            _showOverlay(context);
+            _showCreateShoppingListOverlay(context);
           },
         ),
       ),
     );
   }
 
-  void _showOverlay(BuildContext context) {
+  void _showViewSingleShoppingListOverlay(BuildContext context) {
+    Navigator.of(context).push(
+      FullScreenOverlay(
+        RouteSettings(
+          arguments: FullScreenOverlayRouteArguments(
+            SingleShoppingList(),
+          ),
+        ),
+        ImageFilter.blur(),
+      ),
+    );
+  }
+
+  void _showCreateShoppingListOverlay(BuildContext context) {
     Navigator.of(context).push(
       FullScreenOverlay(
         RouteSettings(
@@ -112,7 +126,7 @@ class ShoppingListsScreen extends StatelessWidget {
                                     ),
                                   ],
                                   onTap: () {
-                                    print('Tapped');
+                                    _showViewSingleShoppingListOverlay(context);
                                   },
                                 );
                               }).toList(),

--- a/lib/screens/shoppingLists.dart
+++ b/lib/screens/shoppingLists.dart
@@ -88,6 +88,9 @@ class ShoppingListsScreen extends StatelessWidget {
                                   horizontal: 30.0,
                                 ),
                                 child: Column(
+                                  // TODO: Group shopping list items by category
+                                  // TODO: Sort items in alphabetical order by name
+                                  // TODO: Immplement search filter
                                   children: result.data['shoppingLists']
                                       .asMap()
                                       .entries

--- a/lib/screens/shoppingLists.dart
+++ b/lib/screens/shoppingLists.dart
@@ -8,9 +8,7 @@ import '../widgets/loadingSpinner.dart';
 import '../widgets/pageTitle.dart';
 import '../widgets/pageSubtitle.dart';
 import '../widgets/tappableCard.dart';
-import '../widgets/fullscreenOverlay.dart';
-import '../widgets/createShoppingListForm.dart';
-import '../widgets/singleShoppingList.dart';
+import '../utils/showOverlayUtils.dart';
 
 class ShoppingListsScreen extends StatelessWidget {
   // Each screen that has a floating action button will have this method
@@ -25,40 +23,9 @@ class ShoppingListsScreen extends StatelessWidget {
           backgroundColor: Colors.green,
           foregroundColor: Colors.white,
           onPressed: () {
-            _showCreateShoppingListOverlay(context);
+            ShowOverlay.showCreateShoppingListOverlay(context);
           },
         ),
-      ),
-    );
-  }
-
-  void _showViewSingleShoppingListOverlay(
-      BuildContext context, Map shoppingListData) {
-    Navigator.of(context).push(
-      FullScreenOverlay(
-        RouteSettings(
-          arguments: FullScreenOverlayRouteArguments(
-            SingleShoppingList(
-              shoppingListData: shoppingListData,
-            ),
-          ),
-        ),
-        ImageFilter.blur(),
-      ),
-    );
-  }
-
-  void _showCreateShoppingListOverlay(
-    BuildContext context,
-  ) {
-    Navigator.of(context).push(
-      FullScreenOverlay(
-        RouteSettings(
-          arguments: FullScreenOverlayRouteArguments(
-            CreateShoppingListForm(),
-          ),
-        ),
-        ImageFilter.blur(),
       ),
     );
   }
@@ -137,10 +104,11 @@ class ShoppingListsScreen extends StatelessWidget {
                                         ),
                                       ],
                                       onTap: () {
-                                        _showViewSingleShoppingListOverlay(
-                                            context,
-                                            result.data['shoppingLists']
-                                                [index]);
+                                        ShowOverlay
+                                            .showViewSingleShoppingListOverlay(
+                                                context,
+                                                result.data['shoppingLists']
+                                                    [index]);
                                       },
                                     );
                                   }).toList(),

--- a/lib/services/foodItems.dart
+++ b/lib/services/foodItems.dart
@@ -1,7 +1,7 @@
 class FoodItemsService {
-  static final String getFoodItemsByHouseholdIdQuery = """
-  query FoodItems(\$householdId: Int!) {
-    foodItems(householdId: \$householdId) {
+  static final String foodItemsQuery = """
+  query FoodItems(\$foodItemsQueryInput: FoodItemsQueryInput!) {
+    foodItems(foodItemsQueryInput: \$foodItemsQueryInput) {
       id,
       name,
       category,

--- a/lib/utils/showOverlayUtils.dart
+++ b/lib/utils/showOverlayUtils.dart
@@ -6,6 +6,7 @@ import '../widgets/fullscreenOverlay.dart';
 import '../widgets/createFoodItemForm.dart';
 import '../widgets/createShoppingListForm.dart';
 import '../widgets/singleShoppingList.dart';
+import '../widgets/singleFoodItem.dart';
 
 // Class that takes care of rendering various overlay screens
 class ShowOverlay {
@@ -15,6 +16,23 @@ class ShowOverlay {
         RouteSettings(
           arguments: FullScreenOverlayRouteArguments(
             CreateFoodItemForm(),
+          ),
+        ),
+        ImageFilter.blur(),
+      ),
+    );
+  }
+
+  static void showViewSingleFoodItemOverlay(
+      BuildContext context, Map foodItemData, String shoppingListName) {
+    Navigator.of(context).push(
+      FullScreenOverlay(
+        RouteSettings(
+          arguments: FullScreenOverlayRouteArguments(
+            SingleFoodItem(
+              foodItemData: foodItemData,
+              shoppingListName: shoppingListName,
+            ),
           ),
         ),
         ImageFilter.blur(),

--- a/lib/utils/showOverlayUtils.dart
+++ b/lib/utils/showOverlayUtils.dart
@@ -1,0 +1,55 @@
+import 'dart:ui';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import '../widgets/fullscreenOverlay.dart';
+import '../widgets/createFoodItemForm.dart';
+import '../widgets/createShoppingListForm.dart';
+import '../widgets/singleShoppingList.dart';
+
+// Class that takes care of rendering various overlay screens
+class ShowOverlay {
+  static void showCreateFoodItemOverlay(BuildContext context) {
+    Navigator.of(context).push(
+      FullScreenOverlay(
+        RouteSettings(
+          arguments: FullScreenOverlayRouteArguments(
+            CreateFoodItemForm(),
+          ),
+        ),
+        ImageFilter.blur(),
+      ),
+    );
+  }
+
+  static void showViewSingleShoppingListOverlay(
+      BuildContext context, Map shoppingListData) {
+    Navigator.of(context).push(
+      FullScreenOverlay(
+        RouteSettings(
+          arguments: FullScreenOverlayRouteArguments(
+            SingleShoppingList(
+              shoppingListData: shoppingListData,
+            ),
+          ),
+        ),
+        ImageFilter.blur(),
+      ),
+    );
+  }
+
+  static void showCreateShoppingListOverlay(
+    BuildContext context,
+  ) {
+    Navigator.of(context).push(
+      FullScreenOverlay(
+        RouteSettings(
+          arguments: FullScreenOverlayRouteArguments(
+            CreateShoppingListForm(),
+          ),
+        ),
+        ImageFilter.blur(),
+      ),
+    );
+  }
+}

--- a/lib/widgets/createFoodItemForm.dart
+++ b/lib/widgets/createFoodItemForm.dart
@@ -265,7 +265,6 @@ class _CreateFoodItemFormState extends State<CreateFoodItemForm> {
                       child: RaisedButton(
                         onPressed: () async {
                           if (_formKey.currentState.validate()) {
-                            print('request started');
                             QueryResult result = await client.mutate(
                               MutationOptions(
                                   documentNode: gql(

--- a/lib/widgets/fridgeStatusCard.dart
+++ b/lib/widgets/fridgeStatusCard.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import './tappableCard.dart';
+import 'tappableCard.dart';
 
+// TODO: Implement this
 class FridgeStatusCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return null;
+    return SizedBox.shrink();
   }
 }

--- a/lib/widgets/fullscreenOverlay.dart
+++ b/lib/widgets/fullscreenOverlay.dart
@@ -64,8 +64,6 @@ class FullScreenOverlay extends ModalRoute<void> {
     );
   }
 
-  // This solution from stack overflow is awesome because it's going to teach me how to do animations,
-  // as well as teach me how to extend a component widget, which I assume might be good flutter practice
   @override
   Widget buildTransitions(BuildContext context, Animation<double> animation,
       Animation<double> secondaryAnimation, Widget child) {

--- a/lib/widgets/loadingSpinner.dart
+++ b/lib/widgets/loadingSpinner.dart
@@ -2,11 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 
 class LoadingSpinner extends StatelessWidget {
+  LoadingSpinner({Key key, this.backgroundColor}) : super(key: key);
+
+  final Color backgroundColor;
+
   @override
   Widget build(BuildContext context) {
     return Center(
       child: Container(
-        color: Colors.white,
+        color: this.backgroundColor != null
+            ? this.backgroundColor
+            : Colors.transparent,
         child: SpinKitRing(
           color: Colors.black,
           size: 50.0,

--- a/lib/widgets/loginForm.dart
+++ b/lib/widgets/loginForm.dart
@@ -95,7 +95,9 @@ class _LoginFormState extends State<LoginForm> {
                   Navigator.of(context).push(
                     MaterialPageRoute(
                       builder: (BuildContext context) {
-                        return LoadingSpinner();
+                        return LoadingSpinner(
+                          backgroundColor: Colors.white,
+                        );
                       },
                     ),
                   );

--- a/lib/widgets/pageTitle.dart
+++ b/lib/widgets/pageTitle.dart
@@ -7,7 +7,7 @@ class PageTitle extends StatelessWidget {
     @required this.text,
   }) : super(key: key);
 
-  final text;
+  final String text;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/singleFoodItem.dart
+++ b/lib/widgets/singleFoodItem.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/pageTitle.dart';
+import '../widgets/pageSubtitle.dart';
+
+class SingleFoodItem extends StatelessWidget {
+  SingleFoodItem(
+      {Key key, @required this.foodItemData, @required this.shoppingListName})
+      : super(key: key);
+
+  final Map foodItemData;
+  final String shoppingListName;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(
+        vertical: 30.0,
+        horizontal: 40.0,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          PageTitle(text: 'Item to buy:'),
+          PageSubTitle(
+            text: 'Name: ' + this.foodItemData['name'],
+            topPadding: 10.0,
+          ),
+          PageSubTitle(
+            text: 'Category: ' + this.foodItemData['category'],
+            topPadding: 0.0,
+          ),
+          PageSubTitle(
+            text: 'Amount: ' + this.foodItemData['amount'].toString(),
+            topPadding: 0.0,
+          ),
+          PageSubTitle(
+            text: 'Unit: ' + this.foodItemData['unit'],
+            topPadding: 0.0,
+          ),
+          PageSubTitle(
+            text: 'Shopping List: ' + this.shoppingListName,
+            topPadding: 0.0,
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: <Widget>[
+              ButtonTheme(
+                height: 60.0,
+                minWidth: 60.0,
+                child: RaisedButton(
+                  color: Colors.red,
+                  child: Text(
+                    'Delete',
+                    style: TextStyle(
+                      fontSize: 26.0,
+                      color: Colors.white,
+                    ),
+                  ),
+                  onPressed: () {
+                    print('Tapped delete food item button');
+                  },
+                ),
+              ),
+              ButtonTheme(
+                height: 60.0,
+                minWidth: 60.0,
+                child: RaisedButton(
+                  color: Colors.grey,
+                  child: Text(
+                    'Back',
+                    style: TextStyle(
+                      fontSize: 26.0,
+                      color: Colors.white,
+                    ),
+                  ),
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/singleFoodItem.dart
+++ b/lib/widgets/singleFoodItem.dart
@@ -66,6 +66,23 @@ class SingleFoodItem extends StatelessWidget {
                 height: 60.0,
                 minWidth: 60.0,
                 child: RaisedButton(
+                  color: Colors.lightBlue,
+                  child: Text(
+                    'Edit',
+                    style: TextStyle(
+                      fontSize: 26.0,
+                      color: Colors.white,
+                    ),
+                  ),
+                  onPressed: () {
+                    print('Tapped edit food item button');
+                  },
+                ),
+              ),
+              ButtonTheme(
+                height: 60.0,
+                minWidth: 60.0,
+                child: RaisedButton(
                   color: Colors.grey,
                   child: Text(
                     'Back',

--- a/lib/widgets/singleShoppingList.dart
+++ b/lib/widgets/singleShoppingList.dart
@@ -1,10 +1,41 @@
 import 'package:flutter/material.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import '../services/shoppingLists.dart';
+import 'pageTitle.dart';
+import 'pageSubtitle.dart';
 
 class SingleShoppingList extends StatelessWidget {
+  SingleShoppingList({Key key, @required this.shoppingListData})
+      : super(key: key);
+
+  final Map shoppingListData;
+
   @override
   Widget build(BuildContext context) {
-    return Text('This is a single shopping list!');
+    return Container(
+      child: ListView(
+        shrinkWrap: true,
+        children: <Widget>[
+          Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: 30.0,
+              vertical: 40.0,
+            ),
+            child: PageTitle(
+              text: shoppingListData['name'],
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: 30.0,
+            ),
+            child: PageSubTitle(
+              text: shoppingListData['description'],
+              topPadding: 0.0,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/widgets/singleShoppingList.dart
+++ b/lib/widgets/singleShoppingList.dart
@@ -54,6 +54,10 @@ class SingleShoppingList extends StatelessWidget {
                       text: shoppingListData['description'],
                       topPadding: 0.0,
                     ),
+                    PageSubTitle(
+                      text: 'Items in this list:',
+                      topPadding: 20.0,
+                    ),
                     result.hasException
                         ? Center(
                             child: Text(

--- a/lib/widgets/singleShoppingList.dart
+++ b/lib/widgets/singleShoppingList.dart
@@ -31,8 +31,8 @@ class SingleShoppingList extends StatelessWidget {
         }
 
         return Container(
+          height: MediaQuery.of(context).size.height - 24.0,
           child: ListView(
-            shrinkWrap: true,
             children: <Widget>[
               Padding(
                 padding: EdgeInsets.symmetric(
@@ -48,12 +48,16 @@ class SingleShoppingList extends StatelessWidget {
                   horizontal: 30.0,
                 ),
                 child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    PageSubTitle(
-                      text: shoppingListData['description'],
-                      topPadding: 0.0,
-                    ),
+                    shoppingListData['description'] != ''
+                        ? PageSubTitle(
+                            text: shoppingListData['description'],
+                            topPadding: 0.0,
+                          )
+                        : SizedBox
+                            .shrink(), // SizedBox.shrink() is the empty widget
                     PageSubTitle(
                       text: 'Items in this list:',
                       topPadding: 20.0,

--- a/lib/widgets/singleShoppingList.dart
+++ b/lib/widgets/singleShoppingList.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import '../services/shoppingLists.dart';
+
+class SingleShoppingList extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text('This is a single shopping list!');
+  }
+}

--- a/lib/widgets/singleShoppingList.dart
+++ b/lib/widgets/singleShoppingList.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
-import '../services/shoppingLists.dart';
+import '../services/foodItems.dart';
+import 'loadingSpinner.dart';
 import 'pageTitle.dart';
 import 'pageSubtitle.dart';
+import 'tappableCard.dart';
 
 class SingleShoppingList extends StatelessWidget {
   SingleShoppingList({Key key, @required this.shoppingListData})
@@ -12,30 +14,96 @@ class SingleShoppingList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: ListView(
-        shrinkWrap: true,
-        children: <Widget>[
-          Padding(
-            padding: EdgeInsets.symmetric(
-              horizontal: 30.0,
-              vertical: 40.0,
-            ),
-            child: PageTitle(
-              text: shoppingListData['name'],
-            ),
-          ),
-          Padding(
-            padding: EdgeInsets.symmetric(
-              horizontal: 30.0,
-            ),
-            child: PageSubTitle(
-              text: shoppingListData['description'],
-              topPadding: 0.0,
-            ),
-          ),
-        ],
+    return Query(
+      options: QueryOptions(
+        documentNode: gql(FoodItemsService.foodItemsQuery),
+        variables: {
+          'foodItemsQueryInput': {
+            'shoppingListId': shoppingListData['id'],
+          }
+        },
+        pollInterval: 5,
       ),
+      builder: (QueryResult result,
+          {VoidCallback refetch, FetchMore fetchMore}) {
+        if (result.hasException) {
+          print(result.exception.toString());
+        }
+
+        return Container(
+          child: ListView(
+            shrinkWrap: true,
+            children: <Widget>[
+              Padding(
+                padding: EdgeInsets.symmetric(
+                  horizontal: 30.0,
+                  vertical: 40.0,
+                ),
+                child: PageTitle(
+                  text: shoppingListData['name'],
+                ),
+              ),
+              Padding(
+                padding: EdgeInsets.symmetric(
+                  horizontal: 30.0,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    PageSubTitle(
+                      text: shoppingListData['description'],
+                      topPadding: 0.0,
+                    ),
+                    result.hasException
+                        ? Center(
+                            child: Text(
+                              result.exception.toString(),
+                              style: TextStyle(
+                                color: Colors.red,
+                                fontSize: 20.0,
+                              ),
+                            ),
+                          )
+                        : result.loading
+                            ? LoadingSpinner()
+                            : Column(
+                                children: result.data['foodItems']
+                                    .map<TappableCard>((foodItem) {
+                                  return TappableCard(
+                                    children: <Widget>[
+                                      ListTile(
+                                        leading: Icon(Icons.kitchen),
+                                        contentPadding: EdgeInsets.symmetric(
+                                          horizontal: 15.0,
+                                        ),
+                                        title: Text(foodItem['name']),
+                                        subtitle: foodItem['unit'] != null &&
+                                                foodItem['unit'] != ''
+                                            ? Text(
+                                                foodItem['unit'],
+                                              )
+                                            : null,
+                                        trailing: Text(
+                                          foodItem['amount'].toString(),
+                                          style: TextStyle(
+                                            fontSize: 26.0,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                    onTap: () {
+                                      print('Tapped');
+                                    },
+                                  );
+                                }).toList(),
+                              ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/widgets/singleShoppingList.dart
+++ b/lib/widgets/singleShoppingList.dart
@@ -32,6 +32,8 @@ class SingleShoppingList extends StatelessWidget {
         }
 
         return Container(
+          // Hack that works for my phone, as for some reason the media query overflows by 24px
+          // TODO: Fix this to work for all screen sizes
           height: MediaQuery.of(context).size.height - 24.0,
           child: ListView(
             children: <Widget>[
@@ -129,7 +131,10 @@ class SingleShoppingList extends StatelessWidget {
                                       ),
                                     ],
                                     onTap: () {
-                                      print('Tapped');
+                                      ShowOverlay.showViewSingleFoodItemOverlay(
+                                          context,
+                                          foodItem,
+                                          shoppingListData['name']);
                                     },
                                   );
                                 }).toList(),

--- a/lib/widgets/singleShoppingList.dart
+++ b/lib/widgets/singleShoppingList.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import '../services/foodItems.dart';
+import '../utils/showOverlayUtils.dart';
 import 'loadingSpinner.dart';
 import 'pageTitle.dart';
 import 'pageSubtitle.dart';
@@ -58,9 +59,37 @@ class SingleShoppingList extends StatelessWidget {
                           )
                         : SizedBox
                             .shrink(), // SizedBox.shrink() is the empty widget
-                    PageSubTitle(
-                      text: 'Items in this list:',
-                      topPadding: 20.0,
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: <Widget>[
+                        PageSubTitle(
+                          text: 'Items in this list:',
+                          topPadding: 10.0,
+                        ),
+                        Padding(
+                          padding: EdgeInsets.symmetric(
+                            vertical: 10.0,
+                          ),
+                          child: RaisedButton(
+                            color: Colors.green,
+                            padding: EdgeInsets.all(10.0),
+                            child: Row(
+                              children: <Widget>[
+                                Text(
+                                  'Create Item',
+                                  style: TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 20.0,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            onPressed: () {
+                              ShowOverlay.showCreateFoodItemOverlay(context);
+                            },
+                          ),
+                        ),
+                      ],
                     ),
                     result.hasException
                         ? Center(


### PR DESCRIPTION
Like the creation screens, the single shopping list UI is a fullscreen overlay

DONE:
- Query for food items that match that shopping list
  - Display tappable cards for those food items
- Render button to create food item under that list
- UI for viewing a single food item and all of its data
  - UI to delete food items from the list
  - UI to edit data for food items like update name/unit/amount/etc (mockup, need backend changes to make this fully work)